### PR TITLE
added support for multiple commands in a single comment

### DIFF
--- a/csgobot.py
+++ b/csgobot.py
@@ -225,7 +225,7 @@ def statScrape(teamlink):
     # other stats are maps played, total kills, total deaths, rounds played, K/D ratio
 
 
-def get_team(comment, which_instance=0):
+def get_team(comment, which_instance):
     instance_count = 0
     comment = str(comment).split()
     for num in range(len(comment)):

--- a/csgobot.py
+++ b/csgobot.py
@@ -225,26 +225,38 @@ def statScrape(teamlink):
     # other stats are maps played, total kills, total deaths, rounds played, K/D ratio
 
 
-def get_team(comment):
+def get_team(comment, which_instance=0):
+    instance_count = 0
     comment = str(comment).split()
     for num in range(len(comment)):
         if comment[num] == '!roster' or comment[num] == '!team' or comment[num] == '!player' or comment[
             num] == '!rektby':
-            if comment[num + 1][0] == '"':  # for multi-word teams, players.
-                if comment[num + 1][-1] == '"':
-                    if len(str(comment[num + 1][1:-1])) < 50:
-                        return str(comment[num + 1][1:-1])
-                elif comment[num + 2][-1] == '"' and comment[num + 1][-1] != '"':  # if it is 2 words
-                    if len(str(comment[num + 1][1:] + ' ' + comment[num + 2][:-1])) < 50:
-                        return str(comment[num + 1][1:] + ' ' + comment[num + 2][:-1])
-                elif '"' not in comment[num + 2] and comment[num + 3][-1] != '"':  # if it is 3 words
-                    if len(str(comment[num][1:] + ' ' + comment[num + 2][:] + ' ' + comment[num + 3][:-1])) < 50:
-                        return str(comment[num][1:] + ' ' + comment[num + 2][:] + ' ' + comment[num + 3][:-1])
+            if instance_count == which_instance:
+                if comment[num + 1][0] == '"':  # for multi-word teams, players.
+                    if comment[num + 1][-1] == '"':
+                        if len(str(comment[num + 1][1:-1])) < 50:
+                            return str(comment[num + 1][1:-1])
+                    elif comment[num + 2][-1] == '"' and comment[num + 1][-1] != '"':  # if it is 2 words
+                        if len(str(comment[num + 1][1:] + ' ' + comment[num + 2][:-1])) < 50:
+                            return str(comment[num + 1][1:] + ' ' + comment[num + 2][:-1])
+                    elif '"' not in comment[num + 2] and comment[num + 3][-1] != '"':  # if it is 3 words
+                        if len(str(comment[num][1:] + ' ' + comment[num + 2][:] + ' ' + comment[num + 3][:-1])) < 50:
+                            return str(comment[num][1:] + ' ' + comment[num + 2][:] + ' ' + comment[num + 3][:-1])
+                    else:
+                        return 'DROP'
                 else:
-                    return 'DROP'
-            else:
-                if len(comment[num + 1]) < 50:
-                    return comment[num + 1]
+                    if len(comment[num + 1]) < 50:
+                        return comment[num + 1]
+            instance_count = instance_count + 1
+
+def get_count(comment):
+    count = 0
+    comment = str(comment).split()
+    for num in range(len(comment)):
+        if comment[num] == '!roster' or comment[num] == '!team' or comment[num] == '!player' or comment[
+            num] == '!rektby':
+            count = count + 1
+    return count
 
 
 def show_table():
@@ -291,149 +303,147 @@ while True:
     subreddit = r.get_subreddit('globaloffensive')
     comments = subreddit.get_comments()
     flat_comments = praw.helpers.flatten_tree(comments)
+    comment_reply = ""
     for comment in flat_comments:
         print comment
-        has_team_call = rcall[0] in comment.body or rcall[1] in comment.body
-        has_player_call = pcall[0] in comment.body or pcall[1] in comment.body
-        if comment.id not in talready_done and has_team_call:
-            team = get_team(comment.body)
-            statfill = '\n\n**Wins:** %s' + ' \n\n**Draws:** %s' + ' \n\n**Losses:** %s' + ' \n\n**Rounds Played:**  %s '
-            if team != '!roster' and team != '!team' and any(
-                    (c in forbidden) for c in team) == False and forbidden2 not in team.upper():
-                stats = []
-                try:
+        call_count = get_count(comment)
+        
+        if comment.id not in talready_done:
+            for instance in range(call_count):
+                team = get_team(comment.body, instance)
+                statfill = '\n\n**Wins:** %s' + ' \n\n**Draws:** %s' + ' \n\n**Losses:** %s' + ' \n\n**Rounds Played:**  %s '
+                if team != '!roster' and team != '!team' and any(
+                        (c in forbidden) for c in team) == False and forbidden2 not in team.upper():
                     stats = []
-                    if team.upper() == 'VP':
-                        team.replace('VP', 'Virtus.Pro')
-                    cur.execute("SELECT * FROM CSGO_TEAMS WHERE TEAM_NAME=(%s) LIMIT 1", (team,))
-                    stats = cur.fetchall()
-                    if len(stats) == 0:
-                        cur.execute("SELECT * FROM CSGO_TEAMS WHERE UPPER(TEAM_NAME)=UPPER(%s) LIMIT 1", (team,))
+                    try:
+                        stats = []
+                        if team.upper() == 'VP':
+                            team.replace('VP', 'Virtus.Pro')
+                        cur.execute("SELECT * FROM CSGO_TEAMS WHERE TEAM_NAME=(%s) LIMIT 1", (team,))
                         stats = cur.fetchall()
-                    if len(stats) > 0:
-                        unite = []
-                        tstats = stats[0][6:10]
-                        players = stats[0][1:6]
-                        team = stats[0][0]
-                        link = stats[0][10]
-                        player_ratings = []
-                        for player in players:
-                            cur.execute("SELECT RATING FROM CSGO_PLAYERS WHERE PLAYER=(%s)",
-                                        (player,))
-                            player_ratings += (cur.fetchall())[0]
-                        fixed_rating = []
-                        for rate in player_ratings:
-                            fixed_rating += [str(rate)]
-                        for num in range(5):
-                            unite.append(players[num])
-                            unite.append(fixed_rating[num])
-                except:
-                    print '~~~~~~ERROR1.~~~~~~'
-                    pass
-                try:
-                    if len(stats) > 0:
-                        format_text = ('\n\nPlayer | Rating ' + '\n:--:|:--:' + ((
-                            '\n %s | %s ' * 5)) + (statfill % (tuple(tstats))) + '\n\n**Win/Loss Ratio:** ' + str(
-                            round((float(tstats[0]) / float(tstats[2])), 2)))
-                except:
-                    print '~~~~~~ERROR2~~~~~~'
-                    pass
-                try:
+                        if len(stats) == 0:
+                            cur.execute("SELECT * FROM CSGO_TEAMS WHERE UPPER(TEAM_NAME)=UPPER(%s) LIMIT 1", (team,))
+                            stats = cur.fetchall()
+                        if len(stats) > 0:
+                            unite = []
+                            tstats = stats[0][6:10]
+                            players = stats[0][1:6]
+                            team = stats[0][0]
+                            link = stats[0][10]
+                            player_ratings = []
+                            for player in players:
+                                cur.execute("SELECT RATING FROM CSGO_PLAYERS WHERE PLAYER=(%s)",
+                                            (player,))
+                                player_ratings += (cur.fetchall())[0]
+                            fixed_rating = []
+                            for rate in player_ratings:
+                                fixed_rating += [str(rate)]
+                            for num in range(5):
+                                unite.append(players[num])
+                                unite.append(fixed_rating[num])
+                    except:
+                        print '~~~~~~ERROR1.~~~~~~'
+                        pass
+                    try:
+                        if len(stats) > 0:
+                            format_text = ('\n\nPlayer | Rating ' + '\n:--:|:--:' + ((
+                                '\n %s | %s ' * 5)) + (statfill % (tuple(tstats))) + '\n\n**Win/Loss Ratio:** ' + str(
+                                round((float(tstats[0]) / float(tstats[2])), 2)))
+                    except:
+                        print '~~~~~~ERROR2~~~~~~'
+                        pass
                     if len(stats) > 0:
                         if link:
                             print format_text
-                            comment.reply(
-                                'Information for **[' + team.replace('&nbsp;', '').replace('%20',
-                                                                                           ' ').upper() + '](http://hltv.org/' + link + ')**:' + (
+                            comment_reply = comment_reply + 'Information for **[' + team.replace('&nbsp;', '').replace('%20',
+                                                                                            ' ').upper() + '](http://hltv.org/' + link + ')**:' + (
                                     (
                                         format_text) % (
                                         tuple(
-                                            unite))) + '\n\n [Powered by HLTV](http://www.hltv.org/)\n\n [GitHub Source](https://github.com/Charrod/csgoteambot) // [Developer\'s Steam](https://steamcommunity.com/id/CHARKbite/)')
+                                            unite))) + '\n\n [Powered by HLTV](http://www.hltv.org/)\n\n [GitHub Source](https://github.com/Charrod/csgoteambot) // [Developer\'s Steam](https://steamcommunity.com/id/CHARKbite/)\n\n'
                             print "~~~~~~~~~Team Comment posted.~~~~~~~~~"
                         else:
                             print format_text
-                            comment.reply(
-                                'Information for **' + team.replace('&nbsp;', '').replace('%20',
-                                                                                           ' ').upper() + '**:' + (
+                            comment_reply = comment_reply + 'Information for **' + team.replace('&nbsp;', '').replace('%20',
+                                                                                            ' ').upper() + '**:' + (
                                     (
                                         format_text) % (
                                         tuple(
-                                            unite))) + '\n\n [Powered by HLTV](http://www.hltv.org/)\n\n [GitHub Source](https://github.com/Charrod/csgoteambot) // [Developer\'s Steam](https://steamcommunity.com/id/CHARKbite/)')
-                            print "~~~~~~~~~Team Comment posted.~~~~~~~~~"
-                except:
-                    print '~~~~~~ERROR3~~~~~~'
-                    pass
+                                            unite))) + '\n\n [Powered by HLTV](http://www.hltv.org/)\n\n [GitHub Source](https://github.com/Charrod/csgoteambot) // [Developer\'s Steam](https://steamcommunity.com/id/CHARKbite/) \n\n'
+
                 unite = []
                 tstats = []
                 players = []
                 team = []
                 link = []
                 player_ratings = []
-                talready_done.append(comment.id)
-                time.sleep(3)
+            talready_done.append(comment.id)
+            time.sleep(3)
 
-                # ---------------------------------------------Player called-----------------------------------------------------
-
-        if comment.id not in palready_done and has_player_call:
-            p = get_team(comment.body)
-            if p != '!roster' and p != '!team' and any(
-                    (c in forbidden) for c in p) == False and forbidden2 not in p.upper():
-                stats = []
-                try:
-                    if p != "CSGOTeamBot":
-                        stats = []
-                        cur.execute("SELECT * FROM CSGO_PLAYERS WHERE PLAYER=(%s) LIMIT 1", (p,))
-                        stats = cur.fetchall()
-                        if len(stats) == 0:
-                            cur.execute("SELECT * FROM CSGO_PLAYERS WHERE UPPER(PLAYER)=UPPER(%s) LIMIT 1", (p,))
+            # ---------------------------------------------Player called-----------------------------------------------------
+        
+        if comment.id not in talready_done:
+            for instance in range(call_count):
+                p = get_team(comment.body, instance)
+                if p != '!roster' and p != '!team' and any(
+                        (c in forbidden) for c in p) == False and forbidden2 not in p.upper():
+                    stats = []
+                    try:
+                        if p != "CSGOTeamBot":
+                            stats = []
+                            cur.execute("SELECT * FROM CSGO_PLAYERS WHERE PLAYER=(%s) LIMIT 1", (p,))
                             stats = cur.fetchall()
-                    elif p == "CSGOTeamBot":
-                        stats = [("n/a", "you now me on reddit nice", "Gabe Newell", "12", "6969", "101", "100", "9.99", "?pageid=179&teamid=6060", "U-Bot")]
-                    if len(stats) > 0:
-                        personal = stats[0][1:4] + (stats[0][9],)
-                        if str(personal[2]) == '99':
-                            personal = personal[0:2] + ('Age data not available.',) + personal[3:]
-                        print personal  # Player, Name, Age, team
-                        KD = stats[0][4:6]
-                        print KD  # Kills, Deaths
+                            if len(stats) == 0:
+                                cur.execute("SELECT * FROM CSGO_PLAYERS WHERE UPPER(PLAYER)=UPPER(%s) LIMIT 1", (p,))
+                                stats = cur.fetchall()
+                        elif p == "CSGOTeamBot":
+                            stats = [("n/a", "you now me on reddit nice", "Gabe Newell", "12", "6969", "101", "100", "9.99", "?pageid=179&teamid=6060", "U-Bot")]
+                        if len(stats) > 0:
+                            personal = stats[0][1:4] + (stats[0][9],)
+                            if str(personal[2]) == '99':
+                                personal = personal[0:2] + ('Age data not available.',) + personal[3:]
+                            print personal  # Player, Name, Age, team
+                            KD = stats[0][4:6]
+                            print KD  # Kills, Deaths
 
-                        HSRating = stats[0][6:8]
-                        print HSRating
-                        link = stats[0][8]
-                        print link
-                    if p != "CSGOTeamBot" and len(stats) > 0:
-                        cur.execute("SELECT LINK FROM CSGO_TEAMS WHERE UPPER(TEAM_NAME)=UPPER(%s) LIMIT 1",
-                                    (personal[-1],))
-                        tlink = cur.fetchall()
-                        tlink = tlink[0][0]
-                        print tlink
-                except:
-                    print '~~~~~~ERROR1~~~~~~'
-                    pass
-                try:
+                            HSRating = stats[0][6:8]
+                            print HSRating
+                            link = stats[0][8]
+                            print link
+                        if p != "CSGOTeamBot" and len(stats) > 0:
+                            cur.execute("SELECT LINK FROM CSGO_TEAMS WHERE UPPER(TEAM_NAME)=UPPER(%s) LIMIT 1",
+                                        (personal[-1],))
+                            tlink = cur.fetchall()
+                            tlink = tlink[0][0]
+                            print tlink
+                    except:
+                        print '~~~~~~ERROR1~~~~~~'
+                        pass
+                    try:
+                        if len(stats) > 0:
+                            format_text = 'Stats | Values' + '\n:--|:--:' + '\nReal Name: | **' + personal[
+                                1] + '**\nAge: | **' + \
+                                          personal[2] + '**\nPrimary Team: | **' + personal[3] + '**\nKills: | **' + str(
+                                KD[0]) + '**\nDeaths: | **' + str(KD[1]) + '**\nKill/Death Ratio: | **' + str(
+                                round((float(KD[0]) / float(KD[1])), 2)) + '**\nHSP: | **' + str(
+                                HSRating[0]) + '%**\nHLTV Rating: | **' + str(HSRating[1]) + '**'
+                    except:
+                        print '~~~~~~ERROR2~~~~~~'
+                        pass
                     if len(stats) > 0:
-                        format_text = 'Stats | Values' + '\n:--|:--:' + '\nReal Name: | **' + personal[
-                            1] + '**\nAge: | **' + \
-                                      personal[2] + '**\nPrimary Team: | **' + personal[3] + '**\nKills: | **' + str(
-                            KD[0]) + '**\nDeaths: | **' + str(KD[1]) + '**\nKill/Death Ratio: | **' + str(
-                            round((float(KD[0]) / float(KD[1])), 2)) + '**\nHSP: | **' + str(
-                            HSRating[0]) + '%**\nHLTV Rating: | **' + str(HSRating[1]) + '**'
-                except:
-                    print '~~~~~~ERROR2~~~~~~'
-                    pass
-                try:
-                    if len(stats) > 0:
-                        comment.reply(
-                            'Information for **[' + personal[
-                                0] + '](http://www.hltv.org/' + link + ')**:\n\n' + format_text + '\n\n [Powered by HLTV](http://www.hltv.org/)\n\n [GitHub Source](https://github.com/Charrod/csgoteambot) // [Developer\'s Steam](https://steamcommunity.com/id/CHARKbite/)')
-                        print "~~~~~~~~~Player Comment posted.~~~~~~~~~"
-                except:
-                    print '~~~~~~ERROR3~~~~~~'
-                    pass
-                stats = []
-                KD = []
-                HSRating = []
-                link = []
-                palready_done.append(comment.id)
+                        comment_reply = comment_reply + '   Information for **[' + personal[
+                                0] + '](http://www.hltv.org/' + link + ')**:\n\n' + format_text + '\n\n [Powered by HLTV](http://www.hltv.org/)\n\n [GitHub Source](https://github.com/Charrod/csgoteambot) // [Developer\'s Steam](https://steamcommunity.com/id/CHARKbite/)\n\n'
+                    stats = []
+                    KD = []
+                    HSRating = []
+                    link = []
+            palready_done.append(comment.id)
+        if comment_reply == "":
+            try:
+                comment.reply(comment_reply)
+                print "~~~~~~~~~Comment posted.~~~~~~~~~"
+            except:
+                print '~~~~~~ERROR3~~~~~~'
+                pass
     conn.close()
     time.sleep(10)

--- a/csgobot.py
+++ b/csgobot.py
@@ -438,7 +438,7 @@ while True:
                     HSRating = []
                     link = []
             palready_done.append(comment.id)
-        if comment_reply == "":
+        if not comment_reply == "":
             try:
                 comment.reply(comment_reply)
                 print "~~~~~~~~~Comment posted.~~~~~~~~~"

--- a/csgobot.py
+++ b/csgobot.py
@@ -303,8 +303,8 @@ while True:
     subreddit = r.get_subreddit('globaloffensive')
     comments = subreddit.get_comments()
     flat_comments = praw.helpers.flatten_tree(comments)
-    comment_reply = ""
     for comment in flat_comments:
+        comment_reply = ""
         print comment
         call_count = get_count(comment)
         


### PR DESCRIPTION
For example "!team Astralis !team CLG" would return the details for both teams ina a single comment. (works if you mix teams and players as well).

It works by getting the number of calls in a comment and get_team now takes a new parameter the call number (in the example above 0  would return Astralis 1 CLG), and rather than posting the reply straight away it adds the contents of the would be comment to comment_reply and actually posts that after all players and teams have been added.

Note that i dont have a DB to hand to test this with but im confident it will work fine. If somebody could point me in the direction of how to set up the correct db as well as the environment variables that would be useful.